### PR TITLE
Decreased the size of chunk size and udp data buffer

### DIFF
--- a/examples/sockets-voice-chat/client-udp.py
+++ b/examples/sockets-voice-chat/client-udp.py
@@ -21,8 +21,8 @@ class Client:
                 break
             except ():
                 print("Couldn't connect to server...")
-        
-        chunk_size = 1024
+
+        chunk_size = 512
         audio_format = pyaudio.paInt16
         channels = 1
         rate = 20000
@@ -39,7 +39,7 @@ class Client:
     def receive_server_data(self):
         while self.connected:
             try:
-                data, addr = self.s.recvfrom(2049)
+                data, addr = self.s.recvfrom(1025)
                 message = Protocol(datapacket=data)
                 if message.DataType == DataType.ClientData:
                     self.playing_stream.write(message.data)
@@ -53,7 +53,7 @@ class Client:
         message = Protocol(dataType=DataType.Handshake, data=self.name.encode(encoding='UTF-8'))
         self.s.sendto(message.out(), self.server)
 
-        data, addr = self.s.recvfrom(2049)
+        data, addr = self.s.recvfrom(1025)
         datapack = Protocol(datapacket=data)
 
         if (addr==self.server and datapack.DataType==DataType.Handshake and 
@@ -65,7 +65,7 @@ class Client:
     def send_data_to_server(self):
         while self.connected:
             try:
-                data = self.recording_stream.read(1024)
+                data = self.recording_stream.read(512)
                 message = Protocol(dataType=DataType.ClientData, data=data)
                 self.s.sendto(message.out(), self.server)
             except:

--- a/examples/sockets-voice-chat/server-udp.py
+++ b/examples/sockets-voice-chat/server-udp.py
@@ -29,7 +29,7 @@ class Server:
         
         while True:
             try:
-                data, addr = self.s.recvfrom(4096)
+                data, addr = self.s.recvfrom(1025)
                 message = Protocol(datapacket=data)
                 self.handleMessage(message, addr)
             except socket.timeout:


### PR DESCRIPTION
Such changes were made due to the problem with UDP packets size receiving on Mac OS X platform.
Seems like all UDP packets for Mac OS X should be under the MTU size (1500 Bytes), otherwise it may be dropped silently. 
In my case it was the problem as i didn't get any packets from server on Windows host to the client on Mac, but the other way from Mac client to server on Windows caused no problems.
Chunk size of recorded audio also was decreased from 1024 to 512 as the data array of bytes contains chunk size * 2 bytes.
